### PR TITLE
Improve error message if CIF file not found

### DIFF
--- a/obsid/obsid.py
+++ b/obsid/obsid.py
@@ -2469,10 +2469,9 @@ class ObsID(FileMain):
         
         # Check whether ccf.cif is produced or not
         ccfcif = glob.glob('ccf.cif')
-        try:
-            os.path.exists(ccfcif[0])
+        if ccfcif and os.path.exists(ccfcif[0]):
             self.logger.info('CIF file {0} created'.format(ccfcif[0]))
-        except FileExistsError:
+        else:
             self.logger.error('The ccf.cif was not produced')
             print('ccf.cif file is not produced')
             sys.exit(1)


### PR DESCRIPTION
I manually downloaded an ODF and forgot to untag them all. That means the cifbuild didn't find the summary file and failed. You can see that in the output below when looking carefully.

However, the actual error that Python throws is different (see pasted in-and output below). It first globs for the `cff.cif` file. If that's not found, glob will return an empty list `[]`. There is a try..except to catch an error, but that catches a `FileExistsError` which gets thrown when we try to create a file that already exists, here the opposite is the case - we try to look for a file that doesn't exist. In particular, we try to get an element from an empty list and that returns an `IndexError`, which is not caught.

To reproduce, set up a data directory with an ODF, but remove the *SUM* file or leave it zipped (it won't be found it the file names ends on ".gz". Then run the code below
```Python
>>> my_obs = pysas.obsid.obsid.ObsID("0963720201", data_dir="/home/idies/workspace/Temporary/hamogu/scratch/XMMdata")
>>> my_obs.basic_setup(repo='sciserver',overwrite=False, run_epproc=False,run_emproc=False,run_rgsproc=False)

20m 47.34s (1.60s)


        Starting SAS session

        Data directory = /home/idies/workspace/Temporary/hamogu/scratch/XMMdata

        
Data found in /home/idies/workspace/Temporary/hamogu/scratch/XMMdata/0963720201/ODF not downloading again.
Data directory: /home/idies/workspace/Temporary/hamogu/scratch/XMMdata

Setting SAS_ODF = /home/idies/workspace/Temporary/hamogu/scratch/XMMdata/0963720201/ODF

Running cifbuild with inputs: {} ...
Executing: 
cifbuild calindexset='ccf.cif' withccfpath='no' ccfpath='.' usecanonicalname='no' recurse='no' fileglob='*.ccf|*.CCF' fullpath='no' withobservationdate='no' observationdate='now' analysisdate='now' category='XMMCCF' ignorecategory='no' masterindex='no' withmasterindexset='no' masterindexset='ccf.mif' append='no'
cifbuild:- Executing (routine): cifbuild calindexset=ccf.cif ccfpath=. withccfpath=no usecanonicalname=no recurse=no fileglob=*.ccf|*.CCF fullpath=no observationdate=now withobservationdate=no analysisdate=now category=XMMCCF ignorecategory=no masterindex=no masterindexset=ccf.mif withmasterindexset=no append=no  -w 1 -V 4
cifbuild:- cifbuild (cifbuild-4.10.1)  [22.1.0-a8f2c2afa-20250304] started:  2026-05-21T00:53:28.000
cifbuild:- Will ask the analysis date to the OAL.
** cifbuild: error (NoSummaryFile), The directory `/home/idies/workspace/Temporary/hamogu/scratch/XMMdata/0963720201/ODF' does not appear to contain an ODF - did not find the summary file which ends in "SUM.ASC" or "SUM.SAS"
cifbuild failed!
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[22], line 1
----> 1 my_obs.basic_setup(repo='sciserver',overwrite=False,
      2                 run_epproc=False,run_emproc=False,run_rgsproc=False)

File ~/miniforge3/envs/xmmsas/lib/python3.11/site-packages/pysas/obsid/obsid.py:468, in ObsID.basic_setup(self, data_dir, repo, overwrite, rerun, recalibrate, run_epproc, run_emproc, run_rgsproc, run_epchain, run_emchain, **kwargs)
    466 # Calibrate ODF data
    467 self.logger.debug('Call calibrate_odf')
--> 468 self.calibrate_odf(obs_dir        = self.obs_dir,
    469                    sas_ccf        = kwargs.get('sas_ccf', None),
    470                    sas_odf        = kwargs.get('sas_odf', None),
    471                    cifbuild_opts  = kwargs.get('cifbuild_opts', {}),
    472                    odfingest_opts = kwargs.get('odfingest_opts', {}),
    473                    recalibrate    = recalibrate)
    475 # Run basic processing
    476 if run_epproc and not run_epchain:

File ~/miniforge3/envs/xmmsas/lib/python3.11/site-packages/pysas/obsid/obsid.py:1106, in ObsID.calibrate_odf(self, obs_dir, sas_ccf, sas_odf, cifbuild_opts, odfingest_opts, recalibrate)
   1103     print('SAS_ODF = {0}'.format(self.files['sas_odf']))
   1104 else:
   1105     # If the ccf.cif or *SUM.SAS files are not present, then run calibration.
-> 1106     self.__run_calibration(cifbuild_opts,odfingest_opts) 
   1108 # Set 'SAS_ODF' enviroment variable.
   1109 os.environ['SAS_ODF'] = self.files['sas_odf']

File ~/miniforge3/envs/xmmsas/lib/python3.11/site-packages/pysas/obsid/obsid.py:1708, in ObsID.__run_calibration(self, cifbuild_opts, odfingest_opts)
   1706 ccfcif = glob.glob('ccf.cif')
   1707 try:
-> 1708     os.path.exists(ccfcif[0])
   1709     self.logger.info('CIF file {0} created'.format(ccfcif[0]))
   1710 except FileExistsError:

IndexError: list index out of range
> /home/idies/miniforge3/envs/xmmsas/lib/python3.11/site-packages/pysas/obsid/obsid.py(1708)__run_calibration()
   1706         ccfcif = glob.glob('ccf.cif')
   1707         try:
-> 1708             os.path.exists(ccfcif[0])
   1709             self.logger.info('CIF file {0} created'.format(ccfcif[0]))
   1710         except FileExistsError:
```